### PR TITLE
Run dependabot only monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,8 @@ updates:
 - package-ecosystem: npm
   directory: '/'
   schedule:
-    interval: weekly
-  open-pull-requests-limit: 10
+    interval: monthly
+  open-pull-requests-limit: 20
   labels:
     - "type: dependencies"
 


### PR DESCRIPTION
As we have discussed in the call, let's update the dependencies only monthly (at least for now). I've also increased the number of allowed PRs since I guess there might be more then 10 updates necessarily per month.