### PR TITLE
Fix line-endings

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "build:dev": "webpack --mode development --https false",
     "build-dev": "webpack --mode development --https false && echo . && echo . && echo . && echo Please use 'build:dev' instead of 'build-dev'.",
     "dev-server": "webpack serve --mode development",
-    "lint": "office-addin-lint check",
-    "lint:fix": "office-addin-lint fix",
-    "prettier": "office-addin-lint prettier",
+    "lint": "office-addin-lint check --files \"src/**/*.{ts,tsx}\"",
+    "lint:fix": "office-addin-lint fix --files \"src/**/*.{ts,tsx}\"",
+    "prettier": "office-addin-lint prettier --files \"src/**/*.{ts,tsx}\"",
     "start": "office-addin-debugging start manifest.xml",
     "start:desktop": "office-addin-debugging start manifest.xml desktop",
     "start:web": "dotenv -- cross-var office-addin-debugging start manifest.xml web --document=%DOCUMENT_URL%",
@@ -26,7 +26,7 @@
     "validate": "office-addin-manifest validate manifest.xml",
     "watch": "webpack --mode development --watch",
     "generate": "graphql-codegen --config codegen.yml",
-    "postinstall": "yarn generate"
+    "postinstall": "yarn generate && crlf --set=LF node_modules/office-addin-*/**/*.js"
   },
   "dependencies": {
     "@apollo/client": "^3.3.19",
@@ -62,6 +62,7 @@
     "babel-loader": "^8.2.2",
     "clean-webpack-plugin": "^3.0.0",
     "copy-webpack-plugin": "^6.4.1",
+    "crlf": "^1.1.1",
     "css-loader": "^5.2.4",
     "eslint": "^7.28.0",
     "eslint-plugin-office-addins": "^0.2.0",


### PR DESCRIPTION
Fixes #65.

Based on [npmtrends](https://www.npmtrends.com/crlf-vs-crlf-normalize-vs-line-ending-corrector-vs-lec) CRLF is fairly popular and appears to work. I haven't tried this on Windows -> PR is draft. But if someone wants to run the validate without using npm this should work.

(I'll test on Windows tomorrow and figure out how to suppress the output)