### PR TITLE
chore: add devcontainer config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+// For format details, see https://aka.ms/devcontainer.json.
+{
+  "name": "Ubuntu",
+  // https://github.com/devcontainers/images/tree/main/src/base-ubuntu
+  "image": "mcr.microsoft.com/vscode/devcontainers/base:ubuntu-22.04",
+
+  // Configure tool-specific properties.
+  "customizations": {
+    // Configure properties specific to VS Code.
+    "vscode": {
+      // Extensions installed when the container is created
+      "extensions": [
+        "msoffice.microsoft-office-add-in-debugger",
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode"
+      ]
+    }
+  },
+
+  "onCreateCommand": "yarn install",
+
+  // Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+  "remoteUser": "vscode",
+  "features": {
+    "node": { "version": "16" }
+  }
+}


### PR DESCRIPTION
Not sure if this is specific to the devcontainer, but running the dev-server works (at least there are no errors reported by webpack) but no content is displayed under `localhost:3000` and requests fail with "The connection was reset". @mohit038 does it still work for you locally?