### PR TITLE
improve: speed up addin loading with webpack code splitting

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,6 +26,30 @@ module.exports = async (env, options) => {
       taskpane: ['react-hot-loader/patch', './src/taskpane/index.tsx'],
       commands: './src/commands/commands.ts',
     },
+    optimization: {
+      splitChunks: {
+        chunks: 'all',
+        minSize: 20000,
+        maxSize: 50000,
+        minChunks: 1,
+        maxAsyncRequests: 30,
+        maxInitialRequests: 30,
+        automaticNameDelimiter: '~',
+        enforceSizeThreshold: 50000,
+        cacheGroups: {
+          defaultVendors: {
+            test: /[\\/]node_modules[\\/]/,
+            priority: -10,
+            reuseExistingChunk: true,
+          },
+          default: {
+            minChunks: 2,
+            priority: -20,
+            reuseExistingChunk: true,
+          },
+        },
+      },
+    },
     output: {
       path: path.resolve(__dirname, 'dist'),
     },


### PR DESCRIPTION
This PR configures the optimization.splitChunks option of webpack to split the code into smaller chunks that can be loaded on demand or in parallel. This reduces the bundle size and the initial loading time of the addin. Previously, `yarn start` took a long time to load. After this PR, the addin will load in considerably less time.





