### PR TITLE
chore: Remove deprecated vscode addin

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,7 +6,6 @@
   "recommendations": [
     "msjsdiag.debugger-for-chrome",
     "msjsdiag.debugger-for-edge",
-    "msoffice.microsoft-office-add-in-debugger",
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode"
   ],


### PR DESCRIPTION
The office addin https://github.com/OfficeDev/vscode-debugger-extension-for-office-addins is deprecated. Instead, the docs now recommend to simply attach via vscode's built-in debugger: https://learn.microsoft.com/en-us/office/dev/add-ins/testing/debug-desktop-using-edge-chromium

TODO: Still has to be tested/documented